### PR TITLE
Ubuntu 20.04 with docker: trigger reboot

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -16,4 +16,5 @@ galaxy_info:
 
   galaxy_tags: []
 
-dependencies: []
+dependencies:
+   - { role: "reboot" }

--- a/tasks/Ubuntu_20.04_runtime_docker.yml
+++ b/tasks/Ubuntu_20.04_runtime_docker.yml
@@ -24,6 +24,16 @@
       - docker-ce-cli
     state: 'present'
   ignore_errors: '{{ ansible_check_mode }}'
+  notify:
+    - 'Reboot'
+
+- name: 'Create directory /etc/systemd/system/docker.service.d'
+  ansible.builtin.file:
+    path: '/etc/systemd/system/docker.service.d'
+    state: 'directory'
+    mode: '0755'
+  notify:
+    - 'Reboot'
 
 - name: 'Create /etc/docker/daemon.json'
   copy:
@@ -40,9 +50,13 @@
     owner: '0'
     group: '0'
     mode: '0644'
+  notify:
+    - 'Reboot'
 
 - name: 'Start and enable the docker service'
   service:
     name: 'docker.service'
     state: 'started'
     enabled: 'true'
+  notify:
+    - 'Reboot'


### PR DESCRIPTION
trigger reboot after preparing files and directories for docker, thus adding role reboot to dependencies