### PR TITLE
Kubernetes on Leap 15.2 is too old

### DIFF
--- a/tasks/openSUSE_Leap.yml
+++ b/tasks/openSUSE_Leap.yml
@@ -22,7 +22,9 @@
     name:
       - kubernetes1.20-kubeadm
       - kubernetes1.20-kubelet
+      - kuberlr
       - cri-o
+      - cri-tools
     state: 'present'
     disable_recommends: 'true'
 

--- a/tasks/openSUSE_Leap.yml
+++ b/tasks/openSUSE_Leap.yml
@@ -32,3 +32,9 @@
   service:
     name: 'kubelet.service'
     enabled: 'true'
+
+- name: 'Disable the docker.service'
+  service:
+    name: 'docker.service'
+    state: 'stopped'
+    enabled: 'false'

--- a/tasks/openSUSE_Leap.yml
+++ b/tasks/openSUSE_Leap.yml
@@ -28,13 +28,12 @@
     state: 'present'
     disable_recommends: 'true'
 
+- name: 'Uninstall docker'
+  package:
+    name: 'docker'
+    state: 'absent'
+
 - name: 'Enable the kubelet.service'
   service:
     name: 'kubelet.service'
     enabled: 'true'
-
-- name: 'Disable the docker.service'
-  service:
-    name: 'docker.service'
-    state: 'stopped'
-    enabled: 'false'

--- a/tasks/openSUSE_Leap.yml
+++ b/tasks/openSUSE_Leap.yml
@@ -1,9 +1,28 @@
 ---
 # install_kubeadm/tasks/main.yml
 
-- name: 'Install patterns-containers-kubeadm on openSUSE 15.x'
+- name: 'Add devel:kubic repository to get a new (and working) version of kubeadm etc.'
+  zypper_repository:
+    name: 'devel:kubic'
+    repo: "https://download.opensuse.org/repositories/devel:/kubic/openSUSE_Leap_{{ ansible_distribution_version }}/"
+    state: 'present'
+    runrefresh: 'yes'
+    auto_import_keys: 'yes'
+
+- name: 'Add repository to get a new (and working) version of kubeadm etc.'
+  zypper_repository:
+    name: 'home:ojkastl_buildservice:Kubernetes_for_Leap'
+    repo: "https://download.opensuse.org/repositories/home:/ojkastl_buildservice:/Kubernetes_for_Leap/openSUSE_Leap_{{ ansible_distribution_version }}/"
+    state: 'present'
+    runrefresh: 'yes'
+    auto_import_keys: 'yes'
+
+- name: 'Install  on openSUSE 15.x'
   zypper:
-    name: 'patterns-containers-kubeadm'
+    name:
+      - kubernetes1.20-kubeadm
+      - kubernetes1.20-kubelet
+      - cri-o
     state: 'present'
     disable_recommends: 'true'
 


### PR DESCRIPTION
Thee container versions do no longer exist, so we add an additional repository to get working versions of kubeadm, kubelet and crio